### PR TITLE
Fixed up Calvins test-lodash function to work inTS

### DIFF
--- a/src/routes/api/test-lodash/+server.ts
+++ b/src/routes/api/test-lodash/+server.ts
@@ -1,0 +1,17 @@
+// Import lodash
+import _ from 'lodash';
+import { readFile } from 'fs/promises';
+
+export async function GET() {
+	console.log('test-lodash function');
+	try {
+		const latexTemplate = await readFile('$lib/templates/test_template.tex', 'utf8');
+		let variableMap = { name: 'Calvin', phone: '4259855538' };
+		_.templateSettings.interpolate = /\@{([\s\S]+?)}/g;
+		let compiled = _.template(latexTemplate);
+		let compiledTemplate = compiled(variableMap);
+		console.log(compiledTemplate);
+	} catch (error) {
+		console.error(error);
+	}
+}

--- a/src/routes/api/test-lodash/+server.ts
+++ b/src/routes/api/test-lodash/+server.ts
@@ -11,6 +11,7 @@ export async function GET() {
 		let compiled = _.template(latexTemplate);
 		let compiledTemplate = compiled(variableMap);
 		console.log(compiledTemplate);
+        return(compiledTemplate);
 	} catch (error) {
 		console.error(error);
 	}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('about page has expected h1', async ({ page }) => {
-	await page.goto('/about');
-	expect(await page.textContent('h1')).toBe('About this app');
+test('info page has expected h1', async ({ page }) => {
+	await page.goto('/info');
+	expect(await page.textContent('h1')).toBe('Info page');
 });


### PR DESCRIPTION
Here I created a new API route in the API diectory called test-lodash/ and used +server.ts to export a GET request. That request reads in a template from $lib/templates/test_tempalte.txt but that file DOES NOT EXIST yet. Plz add that and see if you can get this working.  

Test this api by visiting URL/api/test-lodash